### PR TITLE
Infra: CI/CD v1 파이프라인 구축 (dev & prod)

### DIFF
--- a/.github/workflows/cicd-v1-dev.yaml
+++ b/.github/workflows/cicd-v1-dev.yaml
@@ -2,7 +2,7 @@ name: Frontend CI/CD for dev-v1
 
 on:
   push:
-    branches: [dev, infra/ci-cd]
+    branches: [ dev ]
 
 jobs:
   deploy:
@@ -19,5 +19,5 @@ jobs:
           username: ${{ secrets.DEV_USER }}
           key: ${{ secrets.DEV_SSH_KEY }}
           script: |
-            cd ~/nemo/frontend/scripts
+            cd ~/nemo/cloud/v1/frontend/semi-automated
             bash deploy.sh

--- a/.github/workflows/cicd-v1-prod.yaml
+++ b/.github/workflows/cicd-v1-prod.yaml
@@ -1,0 +1,26 @@
+name: Frontend CI/CD for prod-v1
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: prod
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      - name: Deploy to Dev Server via SSH
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.PROD_HOST }}
+          username: ${{ secrets.PROD_USER }}
+          key: ${{ secrets.PROD_SSH_KEY }}
+          script: |
+            cd ~/nemo/cloud/v1/frontend/semi-automated
+            bash deploy.sh

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -4,34 +4,34 @@
 #   pull_request:
 #     branches: [main, dev]
 
-name: Frontend PR CI
-
-jobs:
-  nextjs-ci:
-    name: PR Check (Next.js with pnpm)
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js 22.14.0
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22.14.0'
-          cache: 'pnpm'
-
-      - name: Install pnpm
-        run: npm install -g pnpm@10.10.0
-
-      - name: Install dependencies with pnpm
-        run: pnpm install
-
-      - name: Run Lint
-        run: pnpm lint
-
-      - name: Type Check
-        run: pnpm type-check
-
-      - name: Build Next.js App
-        run: pnpm build
+#name: Frontend PR CI
+#
+#jobs:
+#  nextjs-ci:
+#    name: PR Check (Next.js with pnpm)
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      - name: Checkout repository
+#        uses: actions/checkout@v4
+#
+#      - name: Setup Node.js 22.14.0
+#        uses: actions/setup-node@v4
+#        with:
+#          node-version: '22.14.0'
+#          cache: 'pnpm'
+#
+#      - name: Install pnpm
+#        run: npm install -g pnpm@10.10.0
+#
+#      - name: Install dependencies with pnpm
+#        run: pnpm install
+#
+#      - name: Run Lint
+#        run: pnpm lint
+#
+#      - name: Type Check
+#        run: pnpm type-check
+#
+#      - name: Build Next.js App
+#        run: pnpm build

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -1,0 +1,37 @@
+# FE와 협의 전으로 CI 자동 실행은 비활성화 상태
+
+# on:
+#   pull_request:
+#     branches: [main, dev]
+
+name: Frontend PR CI
+
+jobs:
+  nextjs-ci:
+    name: PR Check (Next.js with pnpm)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 22.14.0
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.0'
+          cache: 'pnpm'
+
+      - name: Install pnpm
+        run: npm install -g pnpm@10.10.0
+
+      - name: Install dependencies with pnpm
+        run: pnpm install
+
+      - name: Run Lint
+        run: pnpm lint
+
+      - name: Type Check
+        run: pnpm type-check
+
+      - name: Build Next.js App
+        run: pnpm build

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="openjdk-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" default="true">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>


### PR DESCRIPTION
## What

> 무엇을 작업했는지 간결하게 적습니다.

* 운영(prod) 환경 전용 FE CI/CD 워크플로우를 추가하였습니다.

  * `.github/workflows/cicd-v1-prod.yaml`:

    * `main` 브랜치 푸시 → GitHub Actions → `workflow_dispatch` → **수동 승인 후** `deploy.sh` 실행
* 기존 dev용 워크플로우 경로 리팩토링

  * 배포 경로를 `~/nemo/frontend/scripts` → `~/nemo/cloud/v1/frontend/semi-automated` 로 수정
* PR 전용 워크플로우 초안 추가 (`pr-ci.yaml`)

  * 현재 주석 처리된 상태로, 추후 논의 후 적용 예정

## Why

> 왜 이 작업을 했는지 설명합니다.

* 운영 배포는 **자동 실행이 아닌 수동 승인 기반** 플로우로 구분되어야 함
* 실수로 운영 배포가 자동으로 실행되는 것을 방지
* 배포 스크립트 리팩토링에 따른 배포 경로 정리로 dev/prod 공통화 및 명확한 분리 유도

## Changes

> 주요 변경사항을 적습니다.

* `cicd-v1-prod.yaml` 신규 추가
* `cicd-v1.yaml` 내 dev용 경로 수정
* `pr-ci.yaml` PR 전용 워크플로우 초안 추가 (주석 처리 상태)

## Notes

> 참고 내용을 적습니다.

* 운영 배포 실행을 위해 다음 GitHub Secrets 필요:

  * `PROD_SSH_KEY`
  * `PROD_USER`
  * `PROD_HOST`
* 운영 서버 내 다음 경로에 배포 스크립트 존재해야 함:

  * `~/nemo/cloud/v1/frontend/semi-automated/deploy.sh`
* `environment: prod` 설정되어 있으며, GitHub Environments 메뉴에서 **수동 승인자 지정 가능**
* PR CI 관련 워크플로우(`pr-ci.yaml`)는 현재 전체 주석 처리된 상태이며, 향후 적용 여부 논의 예정

## Related Issue

> 관련된 이슈나 과거 작업과의 연관성을 적습니다.
* [[CL] FE 워크플로우 파일 리팩토링 #44](https://github.com/100-hours-a-week/6-nemo-cloud/issues/44)

