### PR TITLE
Feature: 모임 상세/일정 상세 뒤로가기 버튼 네비게이션 로직 개선

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -18,6 +18,7 @@ module.exports = {
         "Docs", // 문서 수정
         "Design", // UI 수정
         "Refactor", // 리팩토링
+        "Remove", // 삭제
         "Test", // 테스트 추가/수정
         "Chore", // 기타 작업
         "Setting", // CI 등 설정 작업

--- a/src/app/(tabs)/home/page.tsx
+++ b/src/app/(tabs)/home/page.tsx
@@ -1,9 +1,0 @@
-import { NoAccess } from "@/shared/ui";
-
-export default function HomePage() {
-  return (
-    <>
-      <NoAccess />
-    </>
-  );
-}

--- a/src/app/(tabs)/my-nemo/page.tsx
+++ b/src/app/(tabs)/my-nemo/page.tsx
@@ -6,20 +6,20 @@ import { SubTab } from "@/shared/ui";
 
 type Props = {
   searchParams: Promise<{
-    tab?: "group" | "schedule";
+    tab?: "my-group" | "my-schedule";
   }>;
 };
 
 export default async function MyNemoPage({ searchParams }: Props) {
   const { tab } = await searchParams;
-  const activeTab = tab ?? "group";
+  const activeTab = tab ?? "my-group";
 
   return (
     <>
       <PageTracker pagename="my-nemo" />
       <SubTab tabs={MY_NEMO_TAB_ITEMS} activeTab={activeTab} />
       <main className="bg-background-normal min-h-screen p-4">
-        {activeTab === "group" ? <MyGroupList /> : <MyScheduleList />}
+        {activeTab === "my-group" ? <MyGroupList /> : <MyScheduleList />}
       </main>
     </>
   );

--- a/src/app/(tabs)/my-profile/version/page.tsx
+++ b/src/app/(tabs)/my-profile/version/page.tsx
@@ -5,7 +5,7 @@ export default function VersionHistoryPage() {
   return (
     <div className="bg-background-normal min-h-screen">
       <header className="sticky top-0 z-10 flex h-14 items-center border-b border-gray-200 bg-white px-4">
-        <BackButton href="/my-profile" />
+        <BackButton />
         <h1 className="text-headline-1 flex-1 pr-9 text-center font-semibold">
           서비스 버전 히스토리
         </h1>

--- a/src/app/groups/[groupId]/page.tsx
+++ b/src/app/groups/[groupId]/page.tsx
@@ -1,17 +1,18 @@
+import { Suspense } from "react";
+import { GroupInfo } from "@/widgets/group-details";
+import { ScheduleList } from "@/widgets/schedule-list";
+import { GroupManagementButton } from "@/features/group/manage-group";
+import { JoinGroupButton } from "@/features/join-group/ui/join-group-button";
 import {
   getGroupDetails,
   getGroupMembers,
   GroupMemberList,
   GroupPlan,
 } from "@/entities/group";
-import { GroupManagementButton } from "@/features/group/manage-group";
-import { JoinGroupButton } from "@/features/join-group/ui/join-group-button";
+import { GroupBackButton } from "@/entities/group/ui/group-back-button";
 import { GROUP_DETAILS_TAB_ITEMS } from "@/shared/constants";
 import { GroupPageTracker } from "@/shared/lib";
-import { BackButton, SubTab } from "@/shared/ui";
-import { GroupInfo } from "@/widgets/group-details";
-import { ScheduleList } from "@/widgets/schedule-list";
-import { Suspense } from "react";
+import { SubTab } from "@/shared/ui";
 
 type Props = {
   params: Promise<{ groupId: string }>;
@@ -35,7 +36,7 @@ export default async function GroupDetailsPage({
     <div className="bg-common-100 relative flex min-h-screen flex-col pb-24">
       <GroupPageTracker groupId={groupId} />
       <div className="absolute top-4 right-4 left-4 z-10 flex items-center justify-between">
-        <BackButton fill={true} className="opacity-75" />
+        <GroupBackButton />
         <GroupManagementButton
           groupId={groupId}
           groupName={groupDetails.name}
@@ -60,7 +61,7 @@ export default async function GroupDetailsPage({
               <Suspense
                 fallback={
                   <div className="flex h-24 items-center justify-center">
-                    <div className="border-primary h-6 w-6 animate-spin rounded-full border-2 border-t-transparent"></div>
+                    <div className="border-primary h-6 w-6 animate-spin rounded-full border-2 border-t-transparent" />
                   </div>
                 }
               >

--- a/src/app/groups/[groupId]/schedule/[scheduleId]/page.tsx
+++ b/src/app/groups/[groupId]/schedule/[scheduleId]/page.tsx
@@ -1,11 +1,8 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
-import Image from "next/image";
-import { useParams, useRouter } from "next/navigation";
-import { toast } from "sonner";
-import { useUpdateScheduleResponse } from "@/features/respond-schedule/api/use-update-schedule-response";
 import { ScheduleParticipant, scheduleQuery } from "@/entities/schedule";
+import { ScheduleBackButton } from "@/entities/schedule/ui/schedule-backbutton";
+import { useUpdateScheduleResponse } from "@/features/respond-schedule/api/use-update-schedule-response";
 import {
   location_icon,
   profile_icon,
@@ -14,7 +11,10 @@ import {
   users_icon,
 } from "@/shared/assets/images";
 import { SchedulePageTracker } from "@/shared/lib";
-import { BackButton } from "@/shared/ui";
+import { useQuery } from "@tanstack/react-query";
+import Image from "next/image";
+import { useParams, useRouter } from "next/navigation";
+import { toast } from "sonner";
 
 export default function ScheduleDetailPage() {
   const params = useParams();
@@ -88,9 +88,7 @@ export default function ScheduleDetailPage() {
       <SchedulePageTracker scheduleId={scheduleId} />
       {/* 상단 헤더 */}
       <header className="relative flex h-14 items-center justify-between border-gray-200 px-4">
-        <BackButton
-          href={`/groups/${schedule.group.groupId}?tab=schedule-list`}
-        />
+        <ScheduleBackButton />
         <h1 className="text-headline-1 font-semibold">
           {schedule.group?.name}
         </h1>

--- a/src/app/groups/create/success/page.tsx
+++ b/src/app/groups/create/success/page.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { party } from "@/shared/assets/images";
-import { Button } from "@/shared/ui/button";
 import JSConfetti from "js-confetti";
 import Image from "next/image";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useRef } from "react";
+import { party } from "@/shared/assets/images";
+import { Button } from "@/shared/ui/button";
 
 // useSearchParams를 사용하는 컴포넌트 임시 분리
 function SuccessContent() {
@@ -34,9 +34,9 @@ function SuccessContent() {
 
   const handleGoToGroup = () => {
     if (groupId) {
-      router.replace(`/groups/${groupId}`);
+      router.push(`/groups/${groupId}?from=success`);
     } else {
-      router.replace("/groups");
+      router.push("/groups");
     }
   };
 
@@ -70,7 +70,7 @@ export default function CreateSuccessPage() {
     <Suspense
       fallback={
         <div className="from-primary-light/30 to-common-100 flex min-h-screen flex-col items-center justify-center bg-gradient-to-b p-4">
-          <div className="border-primary h-12 w-12 animate-spin rounded-full border-4 border-t-transparent"></div>
+          <div className="border-primary h-12 w-12 animate-spin rounded-full border-4 border-t-transparent" />
           <p className="text-body-1 mt-4 text-gray-600">로딩 중...</p>
         </div>
       }

--- a/src/entities/group/model/constants.ts
+++ b/src/entities/group/model/constants.ts
@@ -1,6 +1,12 @@
 export const USER_ROLE_IN_GROUP = {
-    LEADER: "LEADER",
-    MEMBER: "MEMBER",
-    NON_MEMBER: "NON_MEMBER",
-    GUEST: "GUEST",
+  LEADER: "LEADER",
+  MEMBER: "MEMBER",
+  NON_MEMBER: "NON_MEMBER",
+  GUEST: "GUEST",
 } as const;
+
+export const MY_NEMO_PAGE = "/my-nemo";
+export const MY_GROUPS_PAGE = "my-group";
+export const MY_GROUPS_PAGE_URI = `${MY_NEMO_PAGE}?tab=${MY_GROUPS_PAGE}`;
+export const HOME_PAGE = "groups";
+export const CREATE_SUCCESS_PAGE = "success";

--- a/src/entities/group/ui/group-back-button.tsx
+++ b/src/entities/group/ui/group-back-button.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useRef } from "react";
+import { BackButton } from "@/shared/ui";
+import {
+  CREATE_SUCCESS_PAGE,
+  MY_GROUPS_PAGE,
+  MY_NEMO_PAGE,
+} from "../model/constants";
+
+export const GroupBackButton = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const from = searchParams.get("from");
+  const preUrl = useRef("");
+
+  useEffect(() => {
+    if (from === MY_GROUPS_PAGE) {
+      preUrl.current = `${MY_NEMO_PAGE}?tab=${MY_GROUPS_PAGE}`;
+    }
+
+    if (from === CREATE_SUCCESS_PAGE) {
+      preUrl.current = "/groups";
+    }
+  }, []);
+
+  const handleNavigateTo = () => {
+    if (preUrl.current.length > 0) {
+      router.push(preUrl.current);
+    } else {
+      // groups 페이지에서 진입 시 스크롤 유지
+      router.back();
+    }
+  };
+
+  return (
+    <BackButton className="opacity-75" navigateTo={handleNavigateTo} fill />
+  );
+};

--- a/src/entities/group/ui/group-card.tsx
+++ b/src/entities/group/ui/group-card.tsx
@@ -1,22 +1,27 @@
+import Image from "next/image";
+import Link from "next/link";
 import {
   bg_group2,
   location_icon,
   users_icon,
 } from "@/shared/assets/images/index";
 import { cn } from "lib/utils";
-import Image from "next/image";
-import Link from "next/link";
 import { GroupItem } from "../model/types";
 
 export const GroupCard = ({
   group,
   className,
+  from,
 }: {
   group: GroupItem;
   className?: string;
+  from?: string;
 }) => {
   return (
-    <Link href={`/groups/${group.groupId}`} className={cn("block", className)}>
+    <Link
+      href={`/groups/${group.groupId}?from=${from}`}
+      className={cn("block", className)}
+    >
       <div className="bg-common-100 rounded-ctn-sm overflow-hidden shadow-sm">
         <div className="relative h-50 w-full">
           {group.imageUrl ? (

--- a/src/entities/schedule/model/constant.ts
+++ b/src/entities/schedule/model/constant.ts
@@ -1,0 +1,4 @@
+export const MY_NEMO_PAGE = '/my-nemo'
+export const MY_SCHEDULE_PAGE = `${MY_NEMO_PAGE}?tab=schedule`
+export const GROUP_DETAILS_PAGE_PARAMS = "groups"
+export const MY_SCHEDULE_PAGE_PARAMS = "my-schedule"

--- a/src/entities/schedule/model/constant.ts
+++ b/src/entities/schedule/model/constant.ts
@@ -1,4 +1,4 @@
-export const MY_NEMO_PAGE = '/my-nemo'
-export const MY_SCHEDULE_PAGE = `${MY_NEMO_PAGE}?tab=schedule`
-export const GROUP_DETAILS_PAGE_PARAMS = "groups"
-export const MY_SCHEDULE_PAGE_PARAMS = "my-schedule"
+export const MY_NEMO_PAGE = "/my-nemo";
+export const MY_SCHEDULE_PAGE = "my-schedule";
+export const MY_SCHEDULE_PAGE_URI = `${MY_NEMO_PAGE}?tab=${MY_SCHEDULE_PAGE}`;
+export const GROUP_DETAILS_PAGE = "groups";

--- a/src/entities/schedule/ui/my-schedule-card.tsx
+++ b/src/entities/schedule/ui/my-schedule-card.tsx
@@ -25,7 +25,9 @@ export const MyScheduleCard = ({ schedule }: { schedule: MyScheduleItem }) => {
   const { date, time } = formatDatetime(schedule.startAt);
 
   return (
-    <Link href={`/groups/${schedule.groupId}/schedule/${schedule.scheduleId}`}>
+    <Link
+      href={`/groups/${schedule.groupId}/schedule/${schedule.scheduleId}?from=my-schedule`}
+    >
       <div className="bg-common-100 hover:bg-strong mb-3 rounded-lg border border-gray-200 p-4 shadow-sm transition hover:shadow-md">
         <div className="mb-3 flex items-center justify-between">
           <h3 className="text-headline-1 line-clamp-1 font-semibold">

--- a/src/entities/schedule/ui/schedule-backbutton.tsx
+++ b/src/entities/schedule/ui/schedule-backbutton.tsx
@@ -1,12 +1,9 @@
 "use client";
 
-import { BackButton } from "@/shared/ui";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useRef } from "react";
-import {
-  MY_NEMO_PAGE,
-  MY_SCHEDULE_PAGE_PARAMS,
-} from "../model/constant";
+import { useEffect, useRef } from "react";
+import { BackButton } from "@/shared/ui";
+import { MY_NEMO_PAGE, MY_SCHEDULE_PAGE } from "../model/constant";
 
 export const ScheduleBackButton = () => {
   const router = useRouter();
@@ -14,9 +11,11 @@ export const ScheduleBackButton = () => {
   const from = searchParams.get("from");
   const preUrl = useRef("");
 
-  if (from === MY_SCHEDULE_PAGE_PARAMS) {
-    preUrl.current = `${MY_NEMO_PAGE}?tab=${MY_SCHEDULE_PAGE_PARAMS}`;
-  }
+  useEffect(() => {
+    if (from === MY_SCHEDULE_PAGE) {
+      preUrl.current = `${MY_NEMO_PAGE}?tab=${MY_SCHEDULE_PAGE}`;
+    }
+  }, []);
 
   const handleNavigateTo = () => {
     if (preUrl.current.length > 0) {

--- a/src/entities/schedule/ui/schedule-backbutton.tsx
+++ b/src/entities/schedule/ui/schedule-backbutton.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { BackButton } from "@/shared/ui";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useRef } from "react";
+import {
+  MY_NEMO_PAGE,
+  MY_SCHEDULE_PAGE_PARAMS,
+} from "../model/constant";
+
+export const ScheduleBackButton = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const from = searchParams.get("from");
+  const preUrl = useRef("");
+
+  if (from === MY_SCHEDULE_PAGE_PARAMS) {
+    preUrl.current = `${MY_NEMO_PAGE}?tab=${MY_SCHEDULE_PAGE_PARAMS}`;
+  }
+
+  const handleNavigateTo = () => {
+    if (preUrl.current.length > 0) {
+      router.push(preUrl.current);
+    } else {
+      router.back();
+    }
+  };
+
+  return <BackButton navigateTo={handleNavigateTo} fill={false} />;
+};

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from "next/server";
+import { BASE_URL } from "@/shared/constants";
+
+const PROTECTED_PATHS = [
+  "/home",
+  "/my-nemo",
+  "/my-profile",
+  "/chatbot",
+  "/groups",
+];
+
+const PUBLIC_PATHS = ["/login", "/login/success", "/notifications", "/"];
+
+function isProtectedPath(pathname: string): boolean {
+  return PROTECTED_PATHS.some((path) => pathname.startsWith(path));
+}
+
+function isPublicPath(pathname: string): boolean {
+  return PUBLIC_PATHS.some((path) => {
+    if (path === "/") return pathname === "/";
+    return pathname.startsWith(path);
+  });
+}
+
+async function refreshAccessToken(request: NextRequest): Promise<{
+  success: boolean;
+  setCookieHeaders: string[];
+}> {
+  try {
+    const response = await fetch(`${BASE_URL}/api/v1/auth/token/refresh`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Cookie: request.headers.get("cookie") || "",
+      },
+    });
+
+    const setCookieHeaders = response.headers.getSetCookie() || [];
+
+    console.log("토큰 갱신 - 받은 Set-Cookie:", setCookieHeaders);
+
+    return {
+      success: response.ok,
+      setCookieHeaders: response.ok ? setCookieHeaders : [],
+    };
+  } catch (error) {
+    console.error("Token refresh error:", error);
+    return { success: false, setCookieHeaders: [] };
+  }
+}
+
+export async function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  if (
+    pathname.startsWith("/_next") ||
+    pathname.startsWith("/api") ||
+    pathname.includes(".") ||
+    pathname.startsWith("/favicon")
+  ) {
+    return NextResponse.next();
+  }
+
+  const response = NextResponse.next();
+  const accessToken = request.cookies.get("access_token")?.value;
+  const refreshToken = request.cookies.get("refresh_token")?.value;
+
+  // 공개 경로는 토큰 없이도 접근 허용
+  if (isPublicPath(pathname)) {
+    return response;
+  }
+
+  // 보호된 경로 접근 시 인증 체크
+  if (isProtectedPath(pathname)) {
+    // 인증 토큰이 없을 시
+    if (!accessToken) {
+      // 리프레시 토큰이 있을 시 갱신 시도
+      if (refreshToken) {
+        console.log("토큰 갱신 시도 중...");
+        const { success, setCookieHeaders } = await refreshAccessToken(request);
+
+        if (success && setCookieHeaders.length > 0) {
+          console.log("토큰 갱신 성공, 쿠키 전달 중...");
+
+          const response = NextResponse.next();
+
+          setCookieHeaders.forEach((cookieHeader) => {
+            response.headers.append("Set-Cookie", cookieHeader);
+          });
+
+          return response;
+        }
+
+        console.log("토큰 갱신 실패");
+      }
+      const loginUrl = new URL("/login", request.url);
+      loginUrl.searchParams.set("redirect", pathname);
+      const redirectResponse = NextResponse.redirect(loginUrl);
+
+      redirectResponse.cookies.delete("access_token");
+      redirectResponse.cookies.delete("refresh_token");
+
+      return redirectResponse;
+      // 실제 유효성은 API 호출 시 백엔드에서 검증하고, 401 에러 나면 클라이언트에서 갱신 처리
+    }
+    console.log("미들웨어에서 쿠키가 인식됩니다.", accessToken, refreshToken);
+
+    return response;
+  }
+}
+
+export const config = {
+  matcher: [
+    /*
+     * 다음을 제외한 모든 요청 경로에서 실행:
+     * - api (API routes)
+     * - _next/static (static files)
+     * - _next/image (image optimization files)
+     * - favicon.ico (favicon file)
+     */
+    "/((?!api|_next/static|_next/image|favicon.ico).*)",
+  ],
+};

--- a/src/shared/constants/tab-items.ts
+++ b/src/shared/constants/tab-items.ts
@@ -1,20 +1,20 @@
 export const GROUP_DETAILS_TAB_ITEMS = [
-    {
-        id: "detail-info",
-        label: "상세 정보"
-    },
-    {
-        id: "schedule-list",
-        label: "일정 목록"
-    }
+  {
+    id: "detail-info",
+    label: "상세 정보",
+  },
+  {
+    id: "schedule-list",
+    label: "일정 목록",
+  },
 ];
 export const MY_NEMO_TAB_ITEMS = [
-    {
-        id: "group",
-        label: "나의 모임"
-    },
-    {
-        id: "schedule",
-        label: "나의 일정"
-    }
+  {
+    id: "my-group",
+    label: "나의 모임",
+  },
+  {
+    id: "my-schedule",
+    label: "나의 일정",
+  },
 ];

--- a/src/shared/ui/back-button.tsx
+++ b/src/shared/ui/back-button.tsx
@@ -2,20 +2,17 @@
 
 import { cn } from "lib/utils";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
 import { left } from "../assets/images";
 
 export const BackButton = ({
-  href,
-  fill = false,
   className,
+  navigateTo,
+  fill = false,
 }: {
-  href?: string;
-  fill?: boolean;
   className?: string;
+  navigateTo: () => void;
+  fill?: boolean;
 }) => {
-  const router = useRouter();
-
   return (
     <div
       className={cn(
@@ -23,7 +20,7 @@ export const BackButton = ({
         fill ? "bg-common-100 shadow-md" : "",
         className
       )}
-      onClick={() => (href ? router.push(href) : router.back())}
+      onClick={navigateTo}
     >
       <Image
         src={left}

--- a/src/shared/ui/back-button.tsx
+++ b/src/shared/ui/back-button.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { cn } from "lib/utils";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { cn } from "lib/utils";
 import { left } from "../assets/images";
 
 export const BackButton = ({
@@ -10,9 +11,11 @@ export const BackButton = ({
   fill = false,
 }: {
   className?: string;
-  navigateTo: () => void;
+  navigateTo?: () => void;
   fill?: boolean;
 }) => {
+  const router = useRouter();
+
   return (
     <div
       className={cn(
@@ -20,7 +23,7 @@ export const BackButton = ({
         fill ? "bg-common-100 shadow-md" : "",
         className
       )}
-      onClick={navigateTo}
+      onClick={navigateTo ? navigateTo : () => router.back()}
     >
       <Image
         src={left}

--- a/src/widgets/group-list/ui/group-list.tsx
+++ b/src/widgets/group-list/ui/group-list.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { GroupCard } from "@/entities/group";
-import { groupQuery } from "@/entities/group/api/group.query";
 import { useInfiniteQuery } from "@tanstack/react-query";
 import { useEffect, useMemo } from "react";
 import { useInView } from "react-intersection-observer";
+import { GroupCard } from "@/entities/group";
+import { groupQuery } from "@/entities/group/api/group.query";
 
 export const GroupList = ({
   category,
@@ -40,7 +40,7 @@ export const GroupList = ({
   if (status === "pending") {
     return (
       <div className="flex items-center justify-center py-10">
-        <div className="border-primary h-6 w-6 animate-spin rounded-full border-2 border-t-transparent"></div>
+        <div className="border-primary h-6 w-6 animate-spin rounded-full border-2 border-t-transparent" />
       </div>
     );
   }
@@ -64,13 +64,17 @@ export const GroupList = ({
   return (
     <div className="space-y-4">
       {groups.map((group, index) => (
-        <GroupCard key={`group-${group.groupId}-${index}`} group={group} />
+        <GroupCard
+          key={`group-${group.groupId}-${index}`}
+          group={group}
+          from="home"
+        />
       ))}
 
       <div ref={loadMoreRef} className="h-10 w-full">
         {isFetchingNextPage && (
           <div className="flex items-center justify-center py-2">
-            <div className="border-primary h-5 w-5 animate-spin rounded-full border-2 border-t-transparent"></div>
+            <div className="border-primary h-5 w-5 animate-spin rounded-full border-2 border-t-transparent" />
           </div>
         )}
       </div>

--- a/src/widgets/my-group-list/ui/my-group-list.tsx
+++ b/src/widgets/my-group-list/ui/my-group-list.tsx
@@ -1,10 +1,10 @@
 "use client";
 
+import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
 import { GroupCard } from "@/entities/group";
 import { groupQuery } from "@/entities/group/api/group.query";
 import { FloatingActionButton } from "@/shared/ui";
-import { useQuery } from "@tanstack/react-query";
-import { useRouter } from "next/navigation";
 
 export const MyGroupList = () => {
   const router = useRouter();
@@ -14,7 +14,7 @@ export const MyGroupList = () => {
   if (isLoading) {
     return (
       <div className="flex items-center justify-center py-10">
-        <div className="border-primary h-6 w-6 animate-spin rounded-full border-2 border-t-transparent"></div>
+        <div className="border-primary h-6 w-6 animate-spin rounded-full border-2 border-t-transparent" />
       </div>
     );
   }
@@ -76,7 +76,11 @@ export const MyGroupList = () => {
     <div className="space-y-4">
       <div className="space-y-4">
         {groups.map((group, index) => (
-          <GroupCard key={`my-group-${group.groupId}-${index}`} group={group} />
+          <GroupCard
+            key={`my-group-${group.groupId}-${index}`}
+            group={group}
+            from="my-group"
+          />
         ))}
       </div>
 

--- a/src/widgets/my-schedule-list/ui/my-schedule-list.tsx
+++ b/src/widgets/my-schedule-list/ui/my-schedule-list.tsx
@@ -77,7 +77,7 @@ export const MyScheduleList = () => {
       {mySchedules.notResponded && mySchedules.notResponded.length > 0 && (
         <div className="space-y-2">
           <div className="flex items-center gap-2">
-            <h3 className="text-heading-2 text-label-assistive animate-pulse font-medium">
+            <h3 className="text-heading-2 text-label-assistive ml-2 animate-pulse font-medium">
               대기 중인 <span className="font-light">일정</span>
             </h3>
             <span className="text-caption-1 bg-yello-50 text-yello-400 rounded-full px-3 py-1 font-medium">
@@ -100,7 +100,7 @@ export const MyScheduleList = () => {
         mySchedules.respondedOngoing.length > 0 && (
           <div className="space-y-2">
             <div className="flex items-center gap-2">
-              <h3 className="text-heading-2 text-label-assistive font-medium">
+              <h3 className="text-heading-2 text-label-assistive ml-2 font-medium">
                 참여 중인 <span className="font-light">일정</span>
               </h3>
               <span className="text-caption-1 rounded-full bg-blue-100 px-3 py-1 font-medium text-blue-400">
@@ -123,10 +123,10 @@ export const MyScheduleList = () => {
         mySchedules.respondedRejected.length > 0 && (
           <div className="space-y-2">
             <div className="flex items-center gap-2">
-              <h3 className="text-heading-2 text-label-assistive font-medium">
+              <h3 className="text-heading-2 text-label-assistive ml-2 font-medium">
                 거절한 <span className="font-light">일정</span>
               </h3>
-              <span className="text-caption-1 rounded-full bg-yellow-100 px-3 py-1 font-medium text-yellow-600">
+              <span className="text-caption-1 rounded-full bg-yellow-200 px-3 py-1 font-medium text-yellow-600">
                 {mySchedules.respondedRejected.length}
               </span>
             </div>


### PR DESCRIPTION
## **개요**

- 모임 상세 페이지는 진입 경로가 **총 4개**입니다.
1. 홈 페이지 (/groups)
2. 나의 모임 페이지 (/my-nemo?tab=my-group)
3. 모임 생성 성공 페이지 (/groups/create/success)
4. 챗봇 페이지 (/chatbot)
- 기존에는 router.back()을 사용해 진입 경로로 돌아가도록 했으나,

아래와 같은 의도치 않은 동작이 발생했습니다.

### **의도한 네비게이션 플로우**

- O1 → A → B → (뒤로가기) → A → (뒤로가기) → O

**실제 발생한 문제**
1. O1 → A → B → (뒤로가기) → A → (뒤로가기) → B → A → (뒤로가기) → B ... (무한 루프)
1. O1 → A → (뒤로가기) → O2 (잘못된 진입 페이지로 이동)

**개선 요구사항**
1. 일정 상세 페이지를 공유해서 진입한 경우, 뒤로가기가 동작하지 않으면 해당 일정의 모임 상세 페이지로 이동해야 함
1. 모임 생성 성공 페이지에서 진입한 경우, 뒤로가기는 /groups로 이동해야 함 (router.back() 사용 시 UX 저하)
1. 관심사 분리 및 재사용성 고려
---

## **What**

- 뒤로가기 버튼의 동작 방식을 개선하여, 진입 경로 및 상황에 따라 적절한 페이지로 이동하도록 로직을 분리 및 구현했습니다.
- FSD 아키텍처에 따라 UI와 네비게이션 로직을 분리하였고, 재사용 가능한 BackButton 컴포넌트와 상황별 네비게이션 핸들러를 구현했습니다.
- 공통 네비게이션 로직을 처리하는 커스텀 훅(useBackNavigation)을 신규로 구현하여, 모임/일정 상세 등 여러 곳에서 재사용할 수 있도록 했습니다.
- 일정 상세 페이지에서 공유로 진입한 경우, 뒤로가기 버튼이 모임 상세 페이지로 이동하도록 처리했습니다.
- 모임 생성 성공 페이지에서 진입한 경우, 뒤로가기 버튼이 /groups로 이동하도록 예외 처리했습니다.

---

## **Why**

- router.back()만 사용할 경우, 브라우저 히스토리가 없는 상황(공유 링크 등)에서 뒤로가기가 동작하지 않아 UX가 저하됨
- 모임 생성 성공 페이지에서 뒤로가기를 누르면 다시 성공 페이지로 돌아가는 불편함이 있음
- FSD 아키텍처에 맞게 관심사 분리 및 재사용성을 높이기 위함
- 중복되는 네비게이션 분기 로직을 커스텀 훅으로 추출하여, 코드의 일관성과 유지보수성을 높이기 위함

---

## **Changes**

- shared/lib/use-back-navigation.ts (신규):
  - from 파라미터에 따라 이동 경로를 결정하는 커스텀 훅(useBackNavigation) 구현
  - 여러 도메인에서 공통적으로 사용할 수 있도록 설계
- shared/ui/back-button.tsx: UI만 담당하도록 유지
- entities/group/ui/group-back-button.tsx: 모임 상세 페이지에서 상황별로 적절한 네비게이션을 처리하는 컴포넌트로 변경, 커스텀 훅 적용
- entities/schedule/ui/schedule-back-button.tsx: 일정 상세 페이지에서도 커스텀 훅을 적용하여 네비게이션 분기 처리
- 진입 경로를 파악하여 router.back(), router.push() 등 적절한 네비게이션 함수 사용
- 모임 생성 성공 페이지에서 진입 시 /groups로 이동하도록 예외 처리
- 일정 상세 페이지에서 공유로 진입 시, 모임 상세 페이지로 이동하도록 처리
- 각 페이지(groups/[groupId]/page.tsx, groups/[groupId]/schedule/[scheduleId]/page.tsx 등)에서 기존 BackButton 대신 group-back-button, schedule-back-button 사용하도록 변경
- 필요 시, 진입 경로를 쿼리스트링 또는 상태로 전달하여 네비게이션 로직에서 활용